### PR TITLE
【Fixed】rails gコマンドの際にassetsファイル、helperが作成されないよう改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,9 +15,11 @@ module InstagramClone
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.generators do |g|
+
       # この二行の記述で自動生成しない設定を作成しています。
       g.assets false
       g.helper false
+
     end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
 #1 

rails gコマンドの際にassetsファイル、helperが作成されないよう改善